### PR TITLE
Truss elements in Structural 2D

### DIFF
--- a/gmsafir.py
+++ b/gmsafir.py
@@ -4591,8 +4591,7 @@ class Myapp: # Use of class only in order to share 'params' as a global variable
         # (Structural): get the NDOFMAX - FEM considered are those with some Mats defined
         if not self.isThermal:
             if(ndims==2):
-                if("trusscormat;1" in ElemVals):
-                    if([k for k in ElemVals["trusscormat;1"] if k!="-1"]!=[]):
+                if(PropPgs["trusscormat;1"]!=[] or PropEnts["trusscormat;1"]!=[]):
                         ndofmax=2
                 if("beamcormat;1" in ElemVals):
                     if([k for k in ElemVals["beamcormat;1"] if k!="-1"]!=[]):


### PR DESCRIPTION
Hello, when trying to create IN file consisting of truss elements only in Structural 2D ndofmax variable is not assigned and throws `UnboundLocalError`.

I've spotted a line that is causing the error (l. 4596). 
```
# (Structural): get the NDOFMAX - FEM considered are those with some Mats defined
        if not self.isThermal:
            if(ndims==2):
--->         if("trusscormat;1" in ElemVals):
                    if([k for k in ElemVals["trusscormat;1"] if k!="-1"]!=[]):
                        ndofmax=2

```
The program is looking for "trusscormat;1" key in `ElemVals` while it is excluded from being added to ElemVals at all in (l. 4500) and no alternative is set for that case:
```
                if(igtyp!='real_sym' and igtyp!='void_sym' and igtyp!="trusscormat"):
```


I suggest to alter the code to look for truss material in `PropPgs` or `PropEnts` as it is set for 3D cases.