### PR TITLE
Shell error handling

### DIFF
--- a/gmsafir.py
+++ b/gmsafir.py
@@ -2323,7 +2323,7 @@ class Myapp: # Use of class only in order to share 'params' as a global variable
             elif('Surface' in ishp and [icateg for icateg in shellmenus4verif if icateg in iparam['name']]!=[]):
                 emsg=self.verifShellGeom(ishp)
                 if emsg!="":
-                    gmsh.logger.write("Error in Shell Geometry: "+str(err), level="error")
+                    gmsh.logger.write("Error in Shell Geometry: "+str(emsg), level="error")
                     return -1
             #
             if ishp in iparam['name'] and (not self.updateStr in iparam['name']) and (not self.removeStr in iparam['name']):


### PR DESCRIPTION
There was a typo in error message variable when shell is improperly defined.

It was spotted by my student when playing around with different types of shell geometries and I have also a question regarding the error he received. Why there is `gmsafir` limitation to make SHELL elements from 4-node surfaces only?

_Sorry, for non-descriptive branch name, it was auto-generated by github._